### PR TITLE
Add pre-commit-hook for formatting source

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,5 +1,5 @@
 -   id: dotnet-format
     name: dotnet-format
-    entry: dotnet format
+    entry: dotnet format --files
     language: system
     files: '\.(cs|vb)$'

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,4 +1,4 @@
-- id: dotnet-format
+-   id: dotnet-format
     name: dotnet-format
     entry: dotnet format
     language: system

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,5 @@
+- id: dotnet-format
+    name: dotnet-format
+    entry: dotnet format
+    language: system
+    files: '\.(cs|vb)$'


### PR DESCRIPTION
This commit is to add the pre-commit hook which format source code of csharp and vb.
It is used the command "dotnet format".

Close #2 