### PR TITLE
Add hook of executing dotnet test

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,4 +7,4 @@
     name: dotnet Unit test
     entry: dotnet-test.sh
     language: script
-    files: '\*Test.(cs|vb)$'
+    files: '\*.(cs|vb)$'

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,4 +7,4 @@
     name: dotnet Unit test
     entry: dotnet-test.sh
     language: script
-    files: '\*.(cs|vb)$'
+    files: '\.(cs|vb)$'

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,3 +3,8 @@
     entry: dotnet format --files
     language: system
     files: '\.(cs|vb)$'
+-   id: dotnet-test
+    name: dotnet Unit test
+    entry: dotnet-test.sh
+    language: script
+    files: '\*Test.(cs|vb)$'

--- a/dotnet-test.sh
+++ b/dotnet-test.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+PARAMS="--nologo -v m"
+for OPT in "$@"
+do
+    case $OPT in
+        -p | --project)
+            if [[ -z "$2" ]]; then
+                exit 1
+            fi
+            PROJECT=$2
+        *)
+            shift 1
+            ;;
+    esac
+done
+
+if [[ -z "$PROJECT" ]]; then
+    echo "-p option is requirement option."
+    exit 1
+fi
+exec dotnet test $PARAMS $PROJECT


### PR DESCRIPTION
It PR is to add the new hook which execute dotnet test command for protect build break.
It hook is to need to have argument of test project or solution.

Close #3 