### PR TITLE
Fix bug of not executable dotnet-test

### DIFF
--- a/dotnet-test.sh
+++ b/dotnet-test.sh
@@ -9,6 +9,7 @@ do
                 exit 1
             fi
             PROJECT=$2
+            ;;
         *)
             shift 1
             ;;


### PR DESCRIPTION
This commit is to fix the bug which do not execute dotnet-test hook,
because permission failed.

Close #7 